### PR TITLE
Mostrar estado durante generación de PDF

### DIFF
--- a/autorizacion.js
+++ b/autorizacion.js
@@ -2,6 +2,11 @@ async function generarAutorizacionPDF() {
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF();
 
+  const mensaje = document.createElement("div");
+  mensaje.className = "pdf-message loading";
+  mensaje.textContent = "Generando PDF...";
+  document.body.appendChild(mensaje);
+
   // Obtener valores del formulario
   const diasValidos = document.getElementById("dias_validos").value;
   const lugarFecha = document.getElementById("lugar_fecha").value;
@@ -86,4 +91,8 @@ async function generarAutorizacionPDF() {
 
   // Descargar PDF
   doc.save("autorizacion_para_circular.pdf");
+  mensaje.classList.remove("loading");
+  mensaje.classList.add("success");
+  mensaje.textContent = "PDF descargado";
+  setTimeout(() => mensaje.remove(), 3000);
 }

--- a/compra_venta.js
+++ b/compra_venta.js
@@ -2,6 +2,11 @@ async function generarPDF() {
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF();
 
+    const mensaje = document.createElement("div");
+    mensaje.className = "pdf-message loading";
+    mensaje.textContent = "Generando PDF...";
+    document.body.appendChild(mensaje);
+
     // Datos fijos del vendedor
     const nombreVendedor = "Jesus Luciano Diaz";
     const domicilioVendedor = "Piedrabuena 1578";
@@ -109,10 +114,18 @@ async function generarPDF() {
 
     let pdfGuardado = false;
 
+    function finalizarMensaje() {
+        mensaje.classList.remove("loading");
+        mensaje.classList.add("success");
+        mensaje.textContent = "PDF descargado";
+        setTimeout(() => mensaje.remove(), 3000);
+    }
+
     function guardarPDF() {
         if (!pdfGuardado) {
             doc.save(nombreArchivo);
             pdfGuardado = true;
+            finalizarMensaje();
         }
     }
 

--- a/datero.js
+++ b/datero.js
@@ -2,6 +2,11 @@ async function generarDateroPDF() {
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF();
 
+  const mensaje = document.createElement("div");
+  mensaje.className = "pdf-message loading";
+  mensaje.textContent = "Generando PDF...";
+  document.body.appendChild(mensaje);
+
   const get = (id, length = 40) => {
     const valor = document.getElementById(id).value.trim();
     return valor || "_".repeat(length);
@@ -71,4 +76,8 @@ async function generarDateroPDF() {
   // Guardar con nombre personalizado
   const nombreArchivo = getNombreArchivo();
   doc.save(nombreArchivo);
+  mensaje.classList.remove("loading");
+  mensaje.classList.add("success");
+  mensaje.textContent = "PDF descargado";
+  setTimeout(() => mensaje.remove(), 3000);
 }

--- a/styles.css
+++ b/styles.css
@@ -294,8 +294,27 @@
       font-size: 18px;
     }
   
-    h2 {
+  h2 {
       font-size: 22px;
     }
   }
+
+.pdf-message {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  padding: 10px 15px;
+  border-radius: 6px;
+  color: #fff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+}
+
+.pdf-message.loading {
+  background-color: #ffc107;
+}
+
+.pdf-message.success {
+  background-color: #28a745;
+}
   


### PR DESCRIPTION
## Resumen
- Añade mensajes visuales durante la generación y descarga de PDFs en los formularios de compra, autorización y datero.
- Incorpora estilos `.pdf-message` con variantes para estados de carga y éxito.

## Pruebas
- `for f in compra_venta.js autorizacion.js datero.js; do node -c $f && echo "$f ok"; done`


------
https://chatgpt.com/codex/tasks/task_e_6893bcadf7cc8322bfc76496093d794f